### PR TITLE
Webkit with two version digits

### DIFF
--- a/src/browser-detection.js
+++ b/src/browser-detection.js
@@ -61,11 +61,11 @@
       data.browser = browser;
       data.version = parseInt(version, 10) || null;
       data.os = os;
-      if (webkit && webkit.length === 4) {
+      if (webkit && webkit.length >= 3) {
         data.webkit = {
           major: parseInt(webkit[1], 10),
           minor: parseInt(webkit[2], 10),
-          patch: parseInt(webkit[3], 10)
+          patch: webkit[3] ? parseInt(webkit[3], 10) : undefined
         };
       }
     }


### PR DESCRIPTION
E.g. sometimes the version is like `123.4+`. In that case we'll leave the patch field undefined.