### PR TITLE
[UPDATE] README.md and bower.json according to a newer tag (0.3.4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Lightweight package to get information about browser, version and OS. Now suppor
 
 ## Installation
 ```sh
-$ bower install git://github.com/franklang/browser-detection#master --save-dev
+$ bower install browserdetection --save-dev
 ```
 
 ## Usage

--- a/bower.json
+++ b/bower.json
@@ -1,4 +1,5 @@
 {
 	"name": "browser-detection",
+        "version": "0.3.4",
 	"main": "src/browser-detection.js"
 }


### PR DESCRIPTION
Hello Johannes,

I just changed "bower.json" according to a newer tag (0.3.4). After you've merged those files to your "master" branch, could you please create this tag so that the bower install command line will be able to get the Edge browsers support code update?

I also corrected the bower install command line in the "README.md".

Many thanks for this great plugin :)
-Frank