### PR TITLE
[FIX] Plugin removed all classes on HTML element before adding its own.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
 	"name": "browser-detection",
-        "version": "0.3.4",
+        "version": "0.3.5",
 	"main": "src/browser-detection.js"
 }

--- a/src/browser-detection.js
+++ b/src/browser-detection.js
@@ -90,7 +90,7 @@
       options = options || {};
 
       if (options.addClasses && data.os && data.browser && data.version) {
-        document.body.parentNode.className += ' ' + data.os + ' ' + data.browser + ' ' + data.browser + '-' + data.version;
+        document.body.parentNode.classList.add(data.os, data.browser, data.browser, data.version);
       }
     }
 


### PR DESCRIPTION
Hello,
initial source code is removing all CSS classes on HTML element before adding its own. That means it couldn't be used with Modernizr or any other javaScript library that works with adding CSS classes on HTML element.

If you accept this pull request, please create a new tag. I also updated bower.json with new tag version (0.3.5).

Have a nice week,
-Frank